### PR TITLE
[todo-mvvm-databinding_newarch] New branch which uses new android arch components

### DIFF
--- a/todoapp/app/build.gradle
+++ b/todoapp/app/build.gradle
@@ -57,6 +57,7 @@ android {
     dataBinding {
         enabled = true
     }
+    buildToolsVersion '25.0.0'
 }
 
 /*
@@ -72,6 +73,14 @@ dependencies {
     compile "com.android.support:support-v4:$rootProject.supportLibraryVersion"
     compile "com.android.support.test.espresso:espresso-idling-resource:$rootProject.espressoVersion"
     compile "com.google.guava:guava:$rootProject.guavaVersion"
+
+
+    compile "com.google.guava:guava:$rootProject.guavaVersion"
+
+    compile "android.arch.lifecycle:runtime:$rootProject.archLifecycleVersion"
+    compile "android.arch.lifecycle:extensions:$rootProject.archLifecycleVersion"
+    annotationProcessor "android.arch.lifecycle:compiler:$rootProject.archLifecycleVersion"
+    compile "android.arch.persistence.room:runtime:$rootProject.archLifecycleVersion"
 
     // Dependencies for local unit tests
     testCompile "junit:junit:$rootProject.ext.junitVersion"

--- a/todoapp/app/proguard-rules.pro
+++ b/todoapp/app/proguard-rules.pro
@@ -26,3 +26,6 @@
 -dontwarn com.squareup.javawriter.JavaWriter
 # Uncomment this if you use Mockito
 -dontwarn org.mockito.**
+
+# Arch components
+-keep class android.arch.** { *; }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/NavigatingActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/NavigatingActivity.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.android.architecture.blueprints.todoapp;
+
+import com.example.android.architecture.blueprints.todoapp.Navigator;
+
+import android.arch.lifecycle.LifecycleActivity;
+import android.arch.lifecycle.LifecycleRegistry;
+import android.arch.lifecycle.LifecycleRegistryOwner;
+import android.os.Bundle;
+import android.os.PersistableBundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+public abstract class NavigatingActivity<T extends Navigator> extends AppCompatActivity implements LifecycleRegistryOwner {
+    LifecycleRegistry mLifecycleRegistry = new LifecycleRegistry(this);
+    T mNavigator;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mNavigator = initNavigator();
+    }
+
+    @Nullable
+    public abstract T initNavigator();
+
+    public void setNavigator(@Nullable T navigator) {
+        mNavigator = navigator;
+    }
+
+    @Nullable
+    public T getNavigator() {
+        return mNavigator;
+    }
+
+    @Override
+    public LifecycleRegistry getLifecycle() {
+        return mLifecycleRegistry;
+    }
+}

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/Navigator.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/Navigator.java
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.example.android.architecture.blueprints.todoapp;
 
-package com.example.android.architecture.blueprints.todoapp.taskdetail;
 
-import com.example.android.architecture.blueprints.todoapp.Navigator;
-
-/**
- * Defines the navigation actions that can be called from the Details screen.
- */
-public interface TaskDetailNavigator extends Navigator {
-
-    void onTaskDeleted();
-
-    void onStartEditTask();
+public interface Navigator {
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TaskViewModel.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
 import android.databinding.Observable;
+import android.databinding.ObservableBoolean;
 import android.databinding.ObservableField;
 import android.support.annotation.Nullable;
 
@@ -50,7 +51,7 @@ public abstract class TaskViewModel extends ViewModel
 
     private final Context mContext;
 
-    private boolean mIsDataLoading;
+    public final ObservableBoolean dataLoading = new ObservableBoolean();
 
     public TaskViewModel(Context context, TasksRepository tasksRepository) {
         mContext = context.getApplicationContext(); // Force use of Application Context.
@@ -74,7 +75,7 @@ public abstract class TaskViewModel extends ViewModel
 
     public void start(String taskId) {
         if (taskId != null) {
-            mIsDataLoading = true;
+            dataLoading.set(true);
             mTasksRepository.getTask(taskId, this);
         }
     }
@@ -90,7 +91,7 @@ public abstract class TaskViewModel extends ViewModel
     }
 
     public void setCompleted(boolean completed) {
-        if (mIsDataLoading) {
+        if (dataLoading.get()) {
             return;
         }
         Task task = mTaskObservable.get();
@@ -111,10 +112,6 @@ public abstract class TaskViewModel extends ViewModel
         return mTaskObservable.get() != null;
     }
 
-    public boolean isDataLoading() {
-        return mIsDataLoading;
-    }
-
     // This could be an observable, but we save a call to Task.getTitleForList() if not needed.
     public String getTitleForList() {
         if (mTaskObservable.get() == null) {
@@ -126,14 +123,14 @@ public abstract class TaskViewModel extends ViewModel
     @Override
     public void onTaskLoaded(Task task) {
         mTaskObservable.set(task);
-        mIsDataLoading = false;
+        dataLoading.set(false);
         //notifyChange(); // For the @Bindable properties
     }
 
     @Override
     public void onDataNotAvailable() {
         mTaskObservable.set(null);
-        mIsDataLoading = false;
+        dataLoading.set(false);
     }
 
     public void deleteTask() {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TaskViewModel.java
@@ -40,9 +40,9 @@ public abstract class TaskViewModel extends ViewModel
 
     public final MutableLiveData<String> snackbarText = new MutableLiveData<>();
 
-    public final MutableLiveData<String> title = new MutableLiveData<>();
+    public final ObservableField<String> title = new ObservableField<>();
 
-    public final MutableLiveData<String> description = new MutableLiveData<>();
+    public final ObservableField<String> description = new ObservableField<>();
 
     private final ObservableField<Task> mTaskObservable = new ObservableField<>();
 
@@ -62,11 +62,11 @@ public abstract class TaskViewModel extends ViewModel
             public void onPropertyChanged(Observable observable, int i) {
                 Task task = mTaskObservable.get();
                 if (task != null) {
-                    title.setValue(task.getTitle());
-                    description.setValue(task.getDescription());
+                    title.set(task.getTitle());
+                    description.set(task.getDescription());
                 } else {
-                    title.setValue(mContext.getString(R.string.no_data));
-                    description.setValue(mContext.getString(R.string.no_data_description));
+                    title.set(mContext.getString(R.string.no_data));
+                    description.set(mContext.getString(R.string.no_data_description));
                 }
             }
         });

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TaskViewModel.java
@@ -16,6 +16,8 @@
 
 package com.example.android.architecture.blueprints.todoapp;
 
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.ViewModel;
 import android.content.Context;
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
@@ -27,18 +29,20 @@ import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
 
+import static android.R.attr.description;
+
 
 /**
  * Abstract class for View Models that expose a single {@link Task}.
  */
-public abstract class TaskViewModel extends BaseObservable
+public abstract class TaskViewModel extends ViewModel
         implements TasksDataSource.GetTaskCallback {
 
-    public final ObservableField<String> snackbarText = new ObservableField<>();
+    public final MutableLiveData<String> snackbarText = new MutableLiveData<>();
 
-    public final ObservableField<String> title = new ObservableField<>();
+    public final MutableLiveData<String> title = new MutableLiveData<>();
 
-    public final ObservableField<String> description = new ObservableField<>();
+    public final MutableLiveData<String> description = new MutableLiveData<>();
 
     private final ObservableField<Task> mTaskObservable = new ObservableField<>();
 
@@ -53,16 +57,16 @@ public abstract class TaskViewModel extends BaseObservable
         mTasksRepository = tasksRepository;
 
         // Exposed observables depend on the mTaskObservable observable:
-        mTaskObservable.addOnPropertyChangedCallback(new OnPropertyChangedCallback() {
+        mTaskObservable.addOnPropertyChangedCallback(new Observable.OnPropertyChangedCallback() {
             @Override
             public void onPropertyChanged(Observable observable, int i) {
                 Task task = mTaskObservable.get();
                 if (task != null) {
-                    title.set(task.getTitle());
-                    description.set(task.getDescription());
+                    title.setValue(task.getTitle());
+                    description.setValue(task.getDescription());
                 } else {
-                    title.set(mContext.getString(R.string.no_data));
-                    description.set(mContext.getString(R.string.no_data_description));
+                    title.setValue(mContext.getString(R.string.no_data));
+                    description.setValue(mContext.getString(R.string.no_data_description));
                 }
             }
         });
@@ -81,7 +85,6 @@ public abstract class TaskViewModel extends BaseObservable
 
     // "completed" is two-way bound, so in order to intercept the new value, use a @Bindable
     // annotation and process it in the setter.
-    @Bindable
     public boolean getCompleted() {
         return mTaskObservable.get().isCompleted();
     }
@@ -97,25 +100,22 @@ public abstract class TaskViewModel extends BaseObservable
         // Notify repository and user
         if (completed) {
             mTasksRepository.completeTask(task);
-            snackbarText.set(mContext.getResources().getString(R.string.task_marked_complete));
+            snackbarText.setValue(mContext.getResources().getString(R.string.task_marked_complete));
         } else {
             mTasksRepository.activateTask(task);
-            snackbarText.set(mContext.getResources().getString(R.string.task_marked_active));
+            snackbarText.setValue(mContext.getResources().getString(R.string.task_marked_active));
         }
     }
 
-    @Bindable
     public boolean isDataAvailable() {
         return mTaskObservable.get() != null;
     }
 
-    @Bindable
     public boolean isDataLoading() {
         return mIsDataLoading;
     }
 
     // This could be an observable, but we save a call to Task.getTitleForList() if not needed.
-    @Bindable
     public String getTitleForList() {
         if (mTaskObservable.get() == null) {
             return "No data";
@@ -127,7 +127,7 @@ public abstract class TaskViewModel extends BaseObservable
     public void onTaskLoaded(Task task) {
         mTaskObservable.set(task);
         mIsDataLoading = false;
-        notifyChange(); // For the @Bindable properties
+        //notifyChange(); // For the @Bindable properties
     }
 
     @Override
@@ -149,7 +149,7 @@ public abstract class TaskViewModel extends BaseObservable
     }
 
     public String getSnackbarText() {
-        return snackbarText.get();
+        return snackbarText.getValue();
     }
 
     @Nullable

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.java
@@ -16,6 +16,7 @@
 
 package com.example.android.architecture.blueprints.todoapp.addedittask;
 
+import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
@@ -27,6 +28,7 @@ import android.support.v7.widget.Toolbar;
 import com.example.android.architecture.blueprints.todoapp.Injection;
 import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.ViewModelHolder;
+import com.example.android.architecture.blueprints.todoapp.tasks.TasksViewModel;
 import com.example.android.architecture.blueprints.todoapp.util.ActivityUtils;
 import com.example.android.architecture.blueprints.todoapp.util.EspressoIdlingResource;
 
@@ -106,31 +108,15 @@ public class AddEditTaskActivity extends AppCompatActivity implements AddEditTas
                     addEditTaskFragment, R.id.contentFrame);
         }
         return addEditTaskFragment;
+
     }
 
     private AddEditTaskViewModel findOrCreateViewModel() {
-        // In a configuration change we might have a ViewModel present. It's retained using the
-        // Fragment Manager.
-        @SuppressWarnings("unchecked")
-        ViewModelHolder<AddEditTaskViewModel> retainedViewModel =
-                (ViewModelHolder<AddEditTaskViewModel>) getSupportFragmentManager()
-                        .findFragmentByTag(ADD_EDIT_VIEWMODEL_TAG);
-
-        if (retainedViewModel != null && retainedViewModel.getViewmodel() != null) {
-            // If the model was retained, return it.
-            return retainedViewModel.getViewmodel();
-        } else {
-            // There is no ViewModel yet, create it.
-            AddEditTaskViewModel viewModel = new AddEditTaskViewModel(
-                    getApplicationContext(),
-                    Injection.provideTasksRepository(getApplicationContext()));
-
-            // and bind it to this Activity's lifecycle using the Fragment Manager.
-            ActivityUtils.addFragmentToActivity(
-                    getSupportFragmentManager(),
-                    ViewModelHolder.createContainer(viewModel),
-                    ADD_EDIT_VIEWMODEL_TAG);
-            return viewModel;
-        }
+        AddEditTaskViewModel model = ViewModelProviders.of(this).get(AddEditTaskViewModel.class);
+        model.init(
+                getApplicationContext(),
+                Injection.provideTasksRepository(getApplicationContext())
+        );
+        return model;
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.java
@@ -114,7 +114,7 @@ public class AddEditTaskFragment extends LifecycleFragment {
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mViewModel.saveTask(mViewModel.title.getValue(), mViewModel.description.getValue());
+                mViewModel.saveTask(mViewModel.title.get(), mViewModel.description.get());
             }
         });
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
@@ -16,6 +16,8 @@
 
 package com.example.android.architecture.blueprints.todoapp.addedittask;
 
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.ViewModel;
 import android.content.Context;
 import android.databinding.ObservableBoolean;
 import android.databinding.ObservableField;
@@ -34,19 +36,22 @@ import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepo
  * {@link com.example.android.architecture.blueprints.todoapp.statistics.StatisticsViewModel} for
  * how to deal with more complex scenarios.
  */
-public class AddEditTaskViewModel implements TasksDataSource.GetTaskCallback {
+public class AddEditTaskViewModel extends ViewModel implements TasksDataSource.GetTaskCallback {
 
-    public final ObservableField<String> title = new ObservableField<>();
+    public MutableLiveData<String> title = new MutableLiveData<>();
 
-    public final ObservableField<String> description = new ObservableField<>();
+    public MutableLiveData<String> description = new MutableLiveData<>();
 
-    public final ObservableBoolean dataLoading = new ObservableBoolean(false);
+    public MutableLiveData<Boolean> dataLoading = new MutableLiveData<Boolean>();
+    {
+        dataLoading.setValue(false);
+    }
 
-    public final ObservableField<String> snackbarText = new ObservableField<>();
+    public final MutableLiveData<String> snackbarText = new MutableLiveData<>();
 
-    private final TasksRepository mTasksRepository;
+    TasksRepository mTasksRepository;
 
-    private final Context mContext;  // To avoid leaks, this must be an Application Context.
+    Context mContext;  // To avoid leaks, this must be an Application Context.
 
     @Nullable
     private String mTaskId;
@@ -57,9 +62,16 @@ public class AddEditTaskViewModel implements TasksDataSource.GetTaskCallback {
 
     private AddEditTaskNavigator mAddEditTaskNavigator;
 
+    public AddEditTaskViewModel() {
+    }
+
+    public void init(Context context, TasksRepository tasksRepository) {
+        this.mContext = context.getApplicationContext(); // Force use of Application Context.
+        this.mTasksRepository = tasksRepository;
+    }
+
     AddEditTaskViewModel(Context context, TasksRepository tasksRepository) {
-        mContext = context.getApplicationContext(); // Force use of Application Context.
-        mTasksRepository = tasksRepository;
+        this.init(context, tasksRepository);
     }
 
     void onActivityCreated(AddEditTaskNavigator navigator) {
@@ -72,7 +84,7 @@ public class AddEditTaskViewModel implements TasksDataSource.GetTaskCallback {
     }
 
     public void start(String taskId) {
-        if (dataLoading.get()) {
+        if (dataLoading.getValue()) {
             // Already loading, ignore.
             return;
         }
@@ -87,15 +99,15 @@ public class AddEditTaskViewModel implements TasksDataSource.GetTaskCallback {
             return;
         }
         mIsNewTask = false;
-        dataLoading.set(true);
+        dataLoading.setValue(true);
         mTasksRepository.getTask(taskId, this);
     }
 
     @Override
     public void onTaskLoaded(Task task) {
-        title.set(task.getTitle());
-        description.set(task.getDescription());
-        dataLoading.set(false);
+        title.setValue(task.getTitle());
+        description.setValue(task.getDescription());
+        dataLoading.setValue(false);
         mIsDataLoaded = true;
 
         // Note that there's no need to notify that the values changed because we're using
@@ -104,7 +116,7 @@ public class AddEditTaskViewModel implements TasksDataSource.GetTaskCallback {
 
     @Override
     public void onDataNotAvailable() {
-        dataLoading.set(false);
+        dataLoading.setValue(false);
     }
 
     // Called when clicking on fab.
@@ -118,7 +130,7 @@ public class AddEditTaskViewModel implements TasksDataSource.GetTaskCallback {
 
     @Nullable
     public String getSnackbarText() {
-        return snackbarText.get();
+        return snackbarText.getValue();
     }
 
     private boolean isNewTask() {
@@ -128,7 +140,7 @@ public class AddEditTaskViewModel implements TasksDataSource.GetTaskCallback {
     private void createTask(String title, String description) {
         Task newTask = new Task(title, description);
         if (newTask.isEmpty()) {
-            snackbarText.set(mContext.getString(R.string.empty_task_message));
+            snackbarText.setValue(mContext.getString(R.string.empty_task_message));
         } else {
             mTasksRepository.saveTask(newTask);
             navigateOnTaskSaved();

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.java
@@ -28,6 +28,8 @@ import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
 
+import static android.content.ContentValues.TAG;
+
 /**
  * ViewModel for the Add/Edit screen.
  * <p>
@@ -38,14 +40,11 @@ import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepo
  */
 public class AddEditTaskViewModel extends ViewModel implements TasksDataSource.GetTaskCallback {
 
-    public MutableLiveData<String> title = new MutableLiveData<>();
+    public ObservableField<String> title = new ObservableField<>();
 
-    public MutableLiveData<String> description = new MutableLiveData<>();
+    public ObservableField<String> description = new ObservableField<>();
 
-    public MutableLiveData<Boolean> dataLoading = new MutableLiveData<Boolean>();
-    {
-        dataLoading.setValue(false);
-    }
+    public ObservableBoolean dataLoading = new ObservableBoolean(false);
 
     public final MutableLiveData<String> snackbarText = new MutableLiveData<>();
 
@@ -84,7 +83,7 @@ public class AddEditTaskViewModel extends ViewModel implements TasksDataSource.G
     }
 
     public void start(String taskId) {
-        if (dataLoading.getValue()) {
+        if (dataLoading.get()) {
             // Already loading, ignore.
             return;
         }
@@ -99,15 +98,15 @@ public class AddEditTaskViewModel extends ViewModel implements TasksDataSource.G
             return;
         }
         mIsNewTask = false;
-        dataLoading.setValue(true);
+        dataLoading.set(true);
         mTasksRepository.getTask(taskId, this);
     }
 
     @Override
     public void onTaskLoaded(Task task) {
-        title.setValue(task.getTitle());
-        description.setValue(task.getDescription());
-        dataLoading.setValue(false);
+        title.set(task.getTitle());
+        description.set(task.getDescription());
+        dataLoading.set(false);
         mIsDataLoaded = true;
 
         // Note that there's no need to notify that the values changed because we're using
@@ -116,7 +115,7 @@ public class AddEditTaskViewModel extends ViewModel implements TasksDataSource.G
 
     @Override
     public void onDataNotAvailable() {
-        dataLoading.setValue(false);
+        dataLoading.set(false);
     }
 
     // Called when clicking on fab.

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.java
@@ -94,7 +94,6 @@ public class StatisticsViewModel extends BaseObservable {
     /**
      * Returns a String showing the number of active tasks.
      */
-    @Bindable
     public String getNumberOfActiveTasks() {
         return mContext.getString(R.string.statistics_active_tasks, mNumberOfActiveTasks);
     }
@@ -102,7 +101,6 @@ public class StatisticsViewModel extends BaseObservable {
     /**
      * Returns a String showing the number of completed tasks.
      */
-    @Bindable
     public String getNumberOfCompletedTasks() {
         return mContext.getString(R.string.statistics_completed_tasks, mNumberOfCompletedTasks);
     }
@@ -110,7 +108,6 @@ public class StatisticsViewModel extends BaseObservable {
     /**
      * Controls whether the stats are shown or a "No data" message.
      */
-    @Bindable
     public boolean isEmpty() {
         return mNumberOfActiveTasks + mNumberOfCompletedTasks == 0;
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActivity.java
@@ -19,24 +19,28 @@ package com.example.android.architecture.blueprints.todoapp.taskdetail;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 
 import com.example.android.architecture.blueprints.todoapp.Injection;
+import com.example.android.architecture.blueprints.todoapp.NavigatingActivity;
 import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.ViewModelHolder;
 import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskActivity;
 import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskFragment;
+import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.util.ActivityUtils;
 
+import static android.app.Activity.RESULT_FIRST_USER;
 import static com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskActivity.ADD_EDIT_RESULT_OK;
 import static com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailFragment.REQUEST_EDIT_TASK;
 
 /**
  * Displays task details screen.
  */
-public class TaskDetailActivity extends AppCompatActivity implements TaskDetailNavigator {
+public class TaskDetailActivity extends NavigatingActivity<TaskDetailNavigatorImpl> {
 
     public static final String EXTRA_TASK_ID = "TASK_ID";
 
@@ -59,16 +63,10 @@ public class TaskDetailActivity extends AppCompatActivity implements TaskDetailN
         TaskDetailFragment taskDetailFragment = findOrCreateViewFragment();
 
         mTaskViewModel = findOrCreateViewModel();
-        mTaskViewModel.setNavigator(this);
+        mTaskViewModel.setNavigator(getNavigator());
 
         // Link View and ViewModel
         taskDetailFragment.setViewModel(mTaskViewModel);
-    }
-
-    @Override
-    protected void onDestroy() {
-        mTaskViewModel.onActivityDestroyed();
-        super.onDestroy();
     }
 
     @NonNull
@@ -142,17 +140,13 @@ public class TaskDetailActivity extends AppCompatActivity implements TaskDetailN
     }
 
     @Override
-    public void onTaskDeleted() {
-        setResult(DELETE_RESULT_OK);
-        // If the task was deleted successfully, go back to the list.
-        finish();
+    public TaskDetailNavigatorImpl initNavigator() {
+        return new TaskDetailNavigatorImpl(this);
     }
 
     @Override
-    public void onStartEditTask() {
-        String taskId = getIntent().getStringExtra(EXTRA_TASK_ID);
-        Intent intent = new Intent(this, AddEditTaskActivity.class);
-        intent.putExtra(AddEditTaskFragment.ARGUMENT_EDIT_TASK_ID, taskId);
-        startActivityForResult(intent, REQUEST_EDIT_TASK);
+    public void setNavigator(@Nullable TaskDetailNavigatorImpl navigator) {
+        super.setNavigator(navigator);
+        mTaskViewModel.setNavigator(navigator);
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
@@ -16,6 +16,8 @@
 
 package com.example.android.architecture.blueprints.todoapp.taskdetail;
 
+import android.arch.lifecycle.LifecycleFragment;
+import android.arch.lifecycle.Observer;
 import android.databinding.Observable;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -36,7 +38,7 @@ import com.example.android.architecture.blueprints.todoapp.util.SnackbarUtils;
 /**
  * Main UI for the task detail screen.
  */
-public class TaskDetailFragment extends Fragment {
+public class TaskDetailFragment extends LifecycleFragment {
 
     public static final String ARGUMENT_TASK_ID = "TASK_ID";
 
@@ -68,20 +70,16 @@ public class TaskDetailFragment extends Fragment {
 
     @Override
     public void onDestroy() {
-        if (mSnackbarCallback != null) {
-            mViewModel.snackbarText.removeOnPropertyChangedCallback(mSnackbarCallback);
-        }
         super.onDestroy();
     }
 
     private void setupSnackbar() {
-        mSnackbarCallback = new Observable.OnPropertyChangedCallback() {
+        mViewModel.snackbarText.observe(this, new Observer<String>() {
             @Override
-            public void onPropertyChanged(Observable observable, int i) {
-                SnackbarUtils.showSnackbar(getView(), mViewModel.getSnackbarText());
+            public void onChanged(@Nullable String s) {
+                SnackbarUtils.showSnackbar(getView(), s);
             }
-        };
-        mViewModel.snackbarText.addOnPropertyChangedCallback(mSnackbarCallback);
+        });
     }
 
     private void setupFab() {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailNavigatorImpl.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailNavigatorImpl.java
@@ -1,0 +1,58 @@
+package com.example.android.architecture.blueprints.todoapp.taskdetail;
+
+import com.example.android.architecture.blueprints.todoapp.NavigatingActivity;
+import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskActivity;
+import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskFragment;
+
+import android.app.Activity;
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleActivity;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.content.Intent;
+
+import static android.arch.lifecycle.Lifecycle.State.CREATED;
+import static android.arch.lifecycle.Lifecycle.State.DESTROYED;
+import static com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailActivity.DELETE_RESULT_OK;
+import static com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailActivity.EXTRA_TASK_ID;
+import static com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailFragment.REQUEST_EDIT_TASK;
+
+/**
+ * Created by gauravbhola on 13/06/17.
+ */
+
+public class TaskDetailNavigatorImpl implements TaskDetailNavigator, LifecycleObserver {
+
+    public NavigatingActivity mActivity;
+
+    public  TaskDetailNavigatorImpl(NavigatingActivity activity) {
+        mActivity = activity;
+        activity.getLifecycle().addObserver(this);
+    }
+
+    @Override
+    public void onTaskDeleted() {
+        mActivity.setResult(DELETE_RESULT_OK);
+        // If the task was deleted successfully, go back to the list.
+        mActivity.finish();
+    }
+
+    @Override
+    public void onStartEditTask() {
+        String taskId = mActivity.getIntent().getStringExtra(EXTRA_TASK_ID);
+        Intent intent = new Intent(mActivity, AddEditTaskActivity.class);
+        intent.putExtra(AddEditTaskFragment.ARGUMENT_EDIT_TASK_ID, taskId);
+        mActivity.startActivityForResult(intent, REQUEST_EDIT_TASK);
+    }
+
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    void onOwnerDestroyed() {
+        if (mActivity.getLifecycle().getCurrentState() == DESTROYED) {
+            mActivity.setNavigator(null);
+            mActivity.getLifecycle().removeObserver(this);
+            return;
+        }
+    }
+}

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.java
@@ -41,11 +41,6 @@ public class TaskDetailViewModel extends TaskViewModel {
         mTaskDetailNavigator = taskDetailNavigator;
     }
 
-    public void onActivityDestroyed() {
-        // Clear references to avoid potential memory leaks.
-        mTaskDetailNavigator = null;
-    }
-
     /**
      * Can be called by the Data Binding Library or the delete menu item.
      */

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksActivity.java
@@ -16,6 +16,7 @@
 
 package com.example.android.architecture.blueprints.todoapp.tasks;
 
+import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -31,6 +32,7 @@ import android.view.MenuItem;
 
 import com.example.android.architecture.blueprints.todoapp.Injection;
 import com.example.android.architecture.blueprints.todoapp.R;
+import com.example.android.architecture.blueprints.todoapp.TaskViewModel;
 import com.example.android.architecture.blueprints.todoapp.ViewModelHolder;
 import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskActivity;
 import com.example.android.architecture.blueprints.todoapp.statistics.StatisticsActivity;
@@ -74,26 +76,12 @@ public class TasksActivity extends AppCompatActivity implements TaskItemNavigato
     private TasksViewModel findOrCreateViewModel() {
         // In a configuration change we might have a ViewModel present. It's retained using the
         // Fragment Manager.
-        @SuppressWarnings("unchecked")
-        ViewModelHolder<TasksViewModel> retainedViewModel =
-                (ViewModelHolder<TasksViewModel>) getSupportFragmentManager()
-                        .findFragmentByTag(TASKS_VIEWMODEL_TAG);
-
-        if (retainedViewModel != null && retainedViewModel.getViewmodel() != null) {
-            // If the model was retained, return it.
-            return retainedViewModel.getViewmodel();
-        } else {
-            // There is no ViewModel yet, create it.
-            TasksViewModel viewModel = new TasksViewModel(
-                    Injection.provideTasksRepository(getApplicationContext()),
-                    getApplicationContext());
-            // and bind it to this Activity's lifecycle using the Fragment Manager.
-            ActivityUtils.addFragmentToActivity(
-                    getSupportFragmentManager(),
-                    ViewModelHolder.createContainer(viewModel),
-                    TASKS_VIEWMODEL_TAG);
-            return viewModel;
-        }
+        TasksViewModel model = ViewModelProviders.of(this).get(TasksViewModel.class);
+        model.init(
+                Injection.provideTasksRepository(getApplicationContext()),
+                getApplication()
+        );
+        return model;
     }
 
     @NonNull

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
@@ -16,6 +16,9 @@
 
 package com.example.android.architecture.blueprints.todoapp.tasks;
 
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.ViewModel;
 import android.content.Context;
 import android.databinding.BaseObservable;
 import android.databinding.Bindable;
@@ -44,7 +47,7 @@ import java.util.List;
  * property changes. This is done by assigning a {@link Bindable} annotation to the property's
  * getter method.
  */
-public class TasksViewModel extends BaseObservable {
+public class TasksViewModel extends ViewModel {
 
     // These observable fields will update Views automatically
     public final ObservableList<Task> items = new ObservableArrayList<>();
@@ -59,11 +62,11 @@ public class TasksViewModel extends BaseObservable {
 
     public final ObservableBoolean tasksAddViewVisible = new ObservableBoolean();
 
-    final ObservableField<String> snackbarText = new ObservableField<>();
+    final MutableLiveData<String> snackbarText = new MutableLiveData<>();
 
     private TasksFilterType mCurrentFiltering = TasksFilterType.ALL_TASKS;
 
-    private final TasksRepository mTasksRepository;
+    private TasksRepository mTasksRepository;
 
     private final ObservableBoolean mIsDataLoadingError = new ObservableBoolean(false);
 
@@ -71,14 +74,20 @@ public class TasksViewModel extends BaseObservable {
 
     private TasksNavigator mNavigator;
 
+    public TasksViewModel() {
+    }
+
+    public void init(TasksRepository repository, Context context) {
+        mContext = context.getApplicationContext(); // Force use of Application Context.
+        mTasksRepository = repository;
+        // Set initial state
+        setFiltering(TasksFilterType.ALL_TASKS);
+    }
+
     public TasksViewModel(
             TasksRepository repository,
             Context context) {
-        mContext = context.getApplicationContext(); // Force use of Application Context.
-        mTasksRepository = repository;
-
-        // Set initial state
-        setFiltering(TasksFilterType.ALL_TASKS);
+        this.init(repository, context);
     }
 
     void setNavigator(TasksNavigator navigator) {
@@ -94,7 +103,6 @@ public class TasksViewModel extends BaseObservable {
         loadTasks(false);
     }
 
-    @Bindable
     public boolean isEmpty() {
         return items.isEmpty();
     }
@@ -141,12 +149,8 @@ public class TasksViewModel extends BaseObservable {
 
     public void clearCompletedTasks() {
         mTasksRepository.clearCompletedTasks();
-        snackbarText.set(mContext.getString(R.string.completed_tasks_cleared));
+        snackbarText.setValue(mContext.getString(R.string.completed_tasks_cleared));
         loadTasks(false, false);
-    }
-
-    public String getSnackbarText() {
-        return snackbarText.get();
     }
 
     /**
@@ -162,15 +166,15 @@ public class TasksViewModel extends BaseObservable {
         if (AddEditTaskActivity.REQUEST_CODE == requestCode) {
             switch (resultCode) {
                 case TaskDetailActivity.EDIT_RESULT_OK:
-                    snackbarText.set(
+                    snackbarText.setValue(
                             mContext.getString(R.string.successfully_saved_task_message));
                     break;
                 case AddEditTaskActivity.ADD_EDIT_RESULT_OK:
-                    snackbarText.set(
+                    snackbarText.setValue(
                             mContext.getString(R.string.successfully_added_task_message));
                     break;
                 case TaskDetailActivity.DELETE_RESULT_OK:
-                    snackbarText.set(
+                    snackbarText.setValue(
                             mContext.getString(R.string.successfully_deleted_task_message));
                     break;
             }
@@ -234,7 +238,7 @@ public class TasksViewModel extends BaseObservable {
 
                 items.clear();
                 items.addAll(tasksToShow);
-                notifyPropertyChanged(BR.empty); // It's a @Bindable so update manually
+                //notifyPropertyChanged(BR.empty); // It's a @Bindable so update manually
             }
 
             @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.java
@@ -103,10 +103,6 @@ public class TasksViewModel extends ViewModel {
         loadTasks(false);
     }
 
-    public boolean isEmpty() {
-        return items.isEmpty();
-    }
-
     public void loadTasks(boolean forceUpdate) {
         loadTasks(forceUpdate, true);
     }
@@ -238,7 +234,6 @@ public class TasksViewModel extends ViewModel {
 
                 items.clear();
                 items.addAll(tasksToShow);
-                //notifyPropertyChanged(BR.empty); // It's a @Bindable so update manually
             }
 
             @Override

--- a/todoapp/app/src/main/res/layout/addtask_frag.xml
+++ b/todoapp/app/src/main/res/layout/addtask_frag.xml
@@ -30,8 +30,8 @@
         android:id="@+id/refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:enabled="@{viewmodel.dataLoading}"
-        app:refreshing="@{viewmodel.dataLoading}">
+        app:enabled="@{viewmodel.dataLoading.value}"
+        app:refreshing="@{viewmodel.dataLoading.value}">
 
         <ScrollView
             android:layout_width="match_parent"
@@ -45,7 +45,7 @@
                 android:paddingLeft="@dimen/activity_horizontal_margin"
                 android:paddingRight="@dimen/activity_horizontal_margin"
                 android:paddingTop="@dimen/activity_vertical_margin"
-                android:visibility="@{viewmodel.dataLoading ? View.GONE : View.VISIBLE}">
+                android:visibility="@{viewmodel.dataLoading.value ? View.GONE : View.VISIBLE}">
 
                 <EditText
                     android:id="@+id/add_task_title"
@@ -53,7 +53,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/title_hint"
                     android:singleLine="true"
-                    android:text="@={viewmodel.title}"
+                    android:text="@={viewmodel.title.value}"
                     android:textAppearance="@style/TextAppearance.AppCompat.Title"/>
 
                 <EditText
@@ -62,7 +62,7 @@
                     android:layout_height="350dp"
                     android:gravity="top"
                     android:hint="@string/description_hint"
-                    android:text="@={viewmodel.description}"/>
+                    android:text="@={viewmodel.description.value}"/>
 
             </LinearLayout>
         </ScrollView>

--- a/todoapp/app/src/main/res/layout/addtask_frag.xml
+++ b/todoapp/app/src/main/res/layout/addtask_frag.xml
@@ -30,8 +30,8 @@
         android:id="@+id/refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:enabled="@{viewmodel.dataLoading.value}"
-        app:refreshing="@{viewmodel.dataLoading.value}">
+        app:enabled="@{viewmodel.dataLoading}"
+        app:refreshing="@{viewmodel.dataLoading}">
 
         <ScrollView
             android:layout_width="match_parent"
@@ -45,7 +45,7 @@
                 android:paddingLeft="@dimen/activity_horizontal_margin"
                 android:paddingRight="@dimen/activity_horizontal_margin"
                 android:paddingTop="@dimen/activity_vertical_margin"
-                android:visibility="@{viewmodel.dataLoading.value ? View.GONE : View.VISIBLE}">
+                android:visibility="@{viewmodel.dataLoading ? View.GONE : View.VISIBLE}">
 
                 <EditText
                     android:id="@+id/add_task_title"
@@ -53,7 +53,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/title_hint"
                     android:singleLine="true"
-                    android:text="@={viewmodel.title.value}"
+                    android:text="@={viewmodel.title}"
                     android:textAppearance="@style/TextAppearance.AppCompat.Title"/>
 
                 <EditText
@@ -62,7 +62,7 @@
                     android:layout_height="350dp"
                     android:gravity="top"
                     android:hint="@string/description_hint"
-                    android:text="@={viewmodel.description.value}"/>
+                    android:text="@={viewmodel.description}"/>
 
             </LinearLayout>
         </ScrollView>

--- a/todoapp/app/src/main/res/layout/taskdetail_frag.xml
+++ b/todoapp/app/src/main/res/layout/taskdetail_frag.xml
@@ -81,7 +81,7 @@
                 android:layout_toRightOf="@id/task_detail_complete"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@{viewmodel.title.value}"
+                android:text="@{viewmodel.title}"
                 android:textAppearance="?android:attr/textAppearanceLarge" />
 
             <TextView
@@ -90,7 +90,7 @@
                 android:layout_below="@id/task_detail_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@{viewmodel.description.value}"
+                android:text="@{viewmodel.description}"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
         </RelativeLayout>

--- a/todoapp/app/src/main/res/layout/taskdetail_frag.xml
+++ b/todoapp/app/src/main/res/layout/taskdetail_frag.xml
@@ -81,7 +81,7 @@
                 android:layout_toRightOf="@id/task_detail_complete"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@{viewmodel.title}"
+                android:text="@{viewmodel.title.value}"
                 android:textAppearance="?android:attr/textAppearanceLarge" />
 
             <TextView
@@ -90,7 +90,7 @@
                 android:layout_below="@id/task_detail_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@{viewmodel.description}"
+                android:text="@{viewmodel.description.value}"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
 
         </RelativeLayout>

--- a/todoapp/app/src/main/res/layout/tasks_frag.xml
+++ b/todoapp/app/src/main/res/layout/tasks_frag.xml
@@ -49,7 +49,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical"
-            android:visibility="@{viewmodel.empty ? View.GONE : View.VISIBLE}">
+            android:visibility="@{viewmodel.items.empty ? View.GONE : View.VISIBLE}">
 
             <TextView
                 android:id="@+id/filteringLabel"
@@ -76,7 +76,7 @@
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
             android:orientation="vertical"
-            android:visibility="@{viewmodel.empty ? View.VISIBLE : View.GONE}">
+            android:visibility="@{viewmodel.items.empty ? View.VISIBLE : View.GONE}">
 
 
             <ImageView

--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +15,7 @@ allprojects {
     repositories {
         jcenter()
         mavenLocal()
+        maven { url 'https://maven.google.com' }
     }
 }
 
@@ -25,13 +26,14 @@ task clean(type: Delete) {
 // Define versions in a single place
 ext {
     // Sdk and tools
-    minSdkVersion = 10
+    minSdkVersion = 14
     targetSdkVersion = 24
     compileSdkVersion = 24
     buildToolsVersion = '24.0.2'
 
     // App dependencies
-    supportLibraryVersion = '24.2.0'
+    archLifecycleVersion = '1.0.0-alpha1'
+    supportLibraryVersion = '25.3.1'
     guavaVersion = '18.0'
     junitVersion = '4.12'
     mockitoVersion = '1.10.19'

--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -27,9 +27,9 @@ task clean(type: Delete) {
 ext {
     // Sdk and tools
     minSdkVersion = 14
-    targetSdkVersion = 24
-    compileSdkVersion = 24
-    buildToolsVersion = '24.0.2'
+    targetSdkVersion = 25
+    compileSdkVersion = 25
+    buildToolsVersion = '25.0.2'
 
     // App dependencies
     archLifecycleVersion = '1.0.0-alpha1'


### PR DESCRIPTION
New branch: **todo-mvvm-databinding_newarch**
I have made an attempt to integrate the new arch components into the todo-mvvm-databinding. So, all the ViewModels now extend `android.arch.lifecycle.ViewModel`.
The original plan was to remove the Observables all together and use LiveData only but it came out that Livedata doesnt support databinding as of now. 

- So all the observables which were interacting with data-binding are still as is.
- The snackbarText is implemented using LiveData
- All the @Bindable methods are now removed and are instead implemented as Observables (only for now). Once the android lifecycle hits 1.0 stable api we can remove all the observables and use LiveData only.
- Next, I would want to integrate the `android.arch.persistence.room` for Tasks storage.